### PR TITLE
Fixed note offs not working

### DIFF
--- a/midi2vjoy/midi2vjoy.py
+++ b/midi2vjoy/midi2vjoy.py
@@ -156,7 +156,7 @@ def joystick_run():
 					vjoy.SetBtn(reading, opt[0], int(opt[1]))
 				elif key[0] == 128:
 					# A button off input
-					vjoy.SetBtn(reading, opt[0], int(opt[1]))
+					vjoy.SetBtn(0, opt[0], int(opt[1]))
 			time.sleep(0.1)
 	except:
 		#traceback.print_exc()


### PR DESCRIPTION
Originally,
```
elif key[0] == 128:
    # A button off input
    vjoy.SetBtn(reading, opt[0], int(opt[1]))
```
sends the reading of the physical button pressed (eg. velocity on piano) for vJoy and vJoy uses this as the state of the virtual button.
But my piano (and I'd guess many other MIDI devices as well) sends a default reading of 64 (pushed with half pressure out of the maximum) for every button release message.
If you change the code to send a 0 every time it receives a status 128 (note off on channel 1) it's fixed. You need to specify every note off in the .conf-file though:
```
midi2vjoy.py:
elif key[0] == 128:
    # A button off input
    vjoy.SetBtn(0, opt[0], int(opt[1]))

example.conf:
# Note on
144     24  1   1

# Note off
128     24  1   1
```
README.md should also probably inform users that 128's must be configured for some devices in addition to 144's.